### PR TITLE
Add -d option to detach ppaperwork HTML server

### DIFF
--- a/ppaperwork.sh
+++ b/ppaperwork.sh
@@ -3,6 +3,7 @@
 USER_MODE=1
 LOCAL_IMAGE=0
 DOX_HTML_SERVER=0
+DOX_SERVER_DETACH=0
 
 # Argument parser
 while [[ $# -gt 0 ]]; do
@@ -19,6 +20,11 @@ while [[ $# -gt 0 ]]; do
         DOX_HTML_SERVER=1
         shift # past argument
         ;;
+
+    -d|--detach)
+        DOX_SERVER_DETACH=1
+        shift
+        ;;
     *)
         shift # past argument
         ;;
@@ -27,11 +33,24 @@ done
 
 
 if [ $DOX_HTML_SERVER == 1 ] ; then
+        DOX_SERVER_NAME="ppaperwork-dox-server-$USER"
+        DOX_SERVER_ARGS=""
+        DOX_SERVER_PORT="8080"
+
+        if [ $DOX_SERVER_DETACH -eq 1 ] ; then
+            DOX_SERVER_ARGS="-d"
+        fi
 
         # Run an http server to be able to watch the doxygen html from a remote server
         echo "<!-- RUN HTTP SERVER PORT 8080 -->"
-        docker run -v $PWD/documentation/doxygen/html:/usr/share/nginx/html:ro -p 8080:80 nginx
+        docker run $DOX_SERVER_ARGS --rm --name $DOX_SERVER_NAME -v $PWD/documentation/doxygen/html:/usr/share/nginx/html:ro -p $DOX_SERVER_PORT:80 nginx
+        server_ok=$?
 
+        if [ $DOX_SERVER_DETACH -eq 1 ] ; then
+            if [ $server_ok -eq 0 ] ; then
+                echo ">> Server started as '$DOX_SERVER_NAME' on port $DOX_SERVER_PORT! use 'docker stop $DOX_SERVER_NAME' to stop"
+            fi
+        fi
 else
 
         # Run the local image of ppaperwork (for dev purpose)


### PR DESCRIPTION
This PR adds the `-d` option to the `ppaperwork.sh` script, which, when used with the `-s` option, detach the server.

This allows to launch the web server, then regenerate the documentation, and refresh the page afterwards.